### PR TITLE
Include pulumi.name in package.json

### DIFF
--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -24,6 +24,7 @@
     },
     "pulumi": {
         "resource": true,
+        "name": "upstash",
         "pluginDownloadURL": "github://api.github.com/upstash/pulumi-upstash"
     }
 }


### PR DESCRIPTION
It's convention in pulumi to include this - not sure why it's missing as the generator typically includes it